### PR TITLE
Update API for update AllergyIntolerance

### DIFF
--- a/app/Http/Controllers/AllergyIntoleranceController.php
+++ b/app/Http/Controllers/AllergyIntoleranceController.php
@@ -5,17 +5,16 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AllergyIntoleranceRequest;
 use App\Http\Resources\AllergyIntoleranceResource;
-use App\Models\Resource;
 use App\Services\FhirService;
 
 class AllergyIntoleranceController extends Controller
 {
     /**
-     * Store a newly created AllergyIntolerance resource in storage.
+     * Store a new AllergyIntolerance resource.
      *
-     * @param  \App\Http\Requests\AllergyIntoleranceRequest  $request
-     * @param  \App\Services\FhirService  $fhirService
-     * @return \Illuminate\Http\JsonResponse
+     * @param AllergyIntoleranceRequest $request The request object.
+     * @param FhirService $fhirService The FhirService instance.
+     * @return \Illuminate\Http\JsonResponse The JSON response containing the created AllergyIntolerance resource.
      */
     public function store(AllergyIntoleranceRequest $request, FhirService $fhirService)
     {
@@ -24,20 +23,21 @@ class AllergyIntoleranceController extends Controller
         return $fhirService->insertData(function () use ($body) {
             $resource = $this->createResource('AllergyIntolerance');
             $allergyIntolerance = $resource->allergyIntolerance()->create($body['allergy_intolerance']);
-            $this->createInstances($allergyIntolerance, 'identifier', $body);
-            $this->createInstances($allergyIntolerance, 'note', $body);
+            $this->createChildModels($allergyIntolerance, $body, ['identifier', 'note']);
             $this->createNestedInstances($allergyIntolerance, 'reaction', $body, ['manifestation', 'note']);
             $this->createResourceContent(AllergyIntoleranceResource::class, $resource);
             return response()->json($resource->allergyIntolerance->first(), 201);
         });
     }
 
+
     /**
-     * Update an existing AllergyIntolerance resource.
+     * Update an AllergyIntolerance resource.
      *
-     * @param AllergyIntoleranceRequest $request The HTTP request instance.
-     * @param FhirService $fhirService The FHIR service instance.
-     * @return \Illuminate\Http\JsonResponse The HTTP response instance.
+     * @param AllergyIntoleranceRequest $request The request object containing the data.
+     * @param int $res_id The ID of the resource to be updated.
+     * @param FhirService $fhirService The FhirService instance for inserting data.
+     * @return \Illuminate\Http\JsonResponse The JSON response containing the updated AllergyIntolerance resource.
      */
     public function update(AllergyIntoleranceRequest $request, int $res_id, FhirService $fhirService)
     {
@@ -49,8 +49,7 @@ class AllergyIntoleranceController extends Controller
             $allergyIntolerance->update($body['allergy_intolerance']);
             $allergyId = $allergyIntolerance->id;
 
-            $this->updateInstances($allergyIntolerance, 'identifier', $body, 'allergy_id', $allergyId);
-            $this->updateInstances($allergyIntolerance, 'note', $body, 'allergy_id', $allergyId);
+            $this->updateChildModels($allergyIntolerance, $body, ['identifier', 'note'], 'allergy_id', $allergyId);
             $this->updateNestedInstances($allergyIntolerance, 'reaction', $body, 'allergy_id', $allergyId, ['manifestation', 'note'], 'allergy_react_id');
 
             $this->createResourceContent(AllergyIntoleranceResource::class, $resource);

--- a/app/Http/Controllers/AllergyIntoleranceController.php
+++ b/app/Http/Controllers/AllergyIntoleranceController.php
@@ -5,14 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AllergyIntoleranceRequest;
 use App\Http\Resources\AllergyIntoleranceResource;
-use App\Models\AllergyIntolerance;
-use App\Models\AllergyIntoleranceIdentifier;
-use App\Models\AllergyIntoleranceNote;
-use App\Models\AllergyIntoleranceReaction;
-use App\Models\AllergyIntoleranceReactionManifestation;
-use App\Models\AllergyIntoleranceReactionNote;
 use App\Models\Resource;
-use App\Models\ResourceContent;
 use App\Services\FhirService;
 
 class AllergyIntoleranceController extends Controller
@@ -24,38 +17,114 @@ class AllergyIntoleranceController extends Controller
      * @param  \App\Services\FhirService  $fhirService
      * @return \Illuminate\Http\JsonResponse
      */
-    public function postAllergyIntolerance(AllergyIntoleranceRequest $request, FhirService $fhirService)
+    public function store(AllergyIntoleranceRequest $request, FhirService $fhirService)
     {
         $body = $this->retrieveJsonPayload($request);
 
         return $fhirService->insertData(function () use ($body) {
-            [$resource, $resourceKey] = $this->createResource('AllergyIntolerance');
-
-            $allergyIntolerance = AllergyIntolerance::create(array_merge($resourceKey, $body['allergy_intolerance']));
-
-            $allergyKey = ['allergy_id' => $allergyIntolerance->id];
-
-            $this->createInstances(AllergyIntoleranceIdentifier::class, $allergyKey, $body, 'identifier');
-            $this->createInstances(AllergyIntoleranceNote::class, $allergyKey, $body, 'note');
-
-            if (isset($body['reaction']) && !empty($body['reaction'])) {
-                $this->createNestedInstances(AllergyIntoleranceReaction::class, $allergyKey, $body, 'reaction', [
-                    [
-                        'model' => AllergyIntoleranceReactionManifestation::class,
-                        'key' => 'allergy_react_id',
-                        'bodyKey' => 'manifestation'
-                    ],
-                    [
-                        'model' => AllergyIntoleranceReactionNote::class,
-                        'key' => 'allergy_react_id',
-                        'bodyKey' => 'note'
-                    ],
-                ]);
-            }
-
+            $resource = $this->createResource('AllergyIntolerance');
+            $allergyIntolerance = $resource->allergyIntolerance()->create($body['allergy_intolerance']);
+            $this->createInstances($allergyIntolerance, 'identifier', $body);
+            $this->createInstances($allergyIntolerance, 'note', $body);
+            $this->createNestedInstances($allergyIntolerance, 'reaction', $body, ['manifestation', 'note']);
             $this->createResourceContent(AllergyIntoleranceResource::class, $resource);
-
             return response()->json($resource->allergyIntolerance->first(), 201);
         });
+    }
+
+    /**
+     * Update an existing AllergyIntolerance resource.
+     *
+     * @param AllergyIntoleranceRequest $request The HTTP request instance.
+     * @param FhirService $fhirService The FHIR service instance.
+     * @return \Illuminate\Http\JsonResponse The HTTP response instance.
+     */
+    public function update(AllergyIntoleranceRequest $request, FhirService $fhirService)
+    {
+        $body = $this->retrieveJsonPayload($request);
+
+        // return $fhirService->insertData(function () use ($body) {
+        $resource = Resource::find($body['allergy_intolerance']['resource_id']);
+
+        $resource->res_version = $resource->res_version + 1;
+        $resourceVersion = $resource->res_version;
+
+        $allergyIntolerance = $resource->allergyIntolerance()->first();
+        $allergyIntolerance->update($body['allergy_intolerance']);
+        $allergyId = $allergyIntolerance->id;
+
+        foreach ($body['identifier'] as $i) {
+            $id = isset($i['id']) ? $i['id'] : null;
+
+            $allergyIntolerance->identifier()->updateOrCreate(
+                ['id' => $id],
+                [
+                    'allergy_id' => $allergyId,
+                    'system' => $i['system'],
+                    'use' => $i['use'],
+                    'value' => $i['value']
+                ]
+            );
+        }
+
+        foreach ($body['note'] as $n) {
+            $id = isset($n['id']) ? $n['id'] : null;
+
+            $allergyIntolerance->note()->updateOrCreate(
+                ['id' => $id],
+                [
+                    'allergy_id' => $allergyId,
+                    'author' => $n['author'],
+                    'time' => $n['time'],
+                    'text' => $n['text']
+                ]
+            );
+        }
+
+        foreach ($body['reaction'] as $r) {
+            $id = isset($r['reaction_data']['id']) ? $r['reaction_data']['id'] : null;
+            unset($r['reaction_data']['id']);
+            unset($r['reaction_data']['allergy_id']);
+
+            $reaction = $allergyIntolerance->reaction()->updateOrCreate(
+                ['id' => $id],
+                array_merge(['allergy_id' => $allergyId], $r['reaction_data'])
+            );
+
+            $reactionId = $reaction->id;
+
+            foreach ($r['manifestation'] as $rm) {
+                $id = isset($rm['id']) ? $rm['id'] : null;
+                unset($rm['id']);
+                unset($rm['allergy_react_id']);
+
+                $reaction->manifestation()->updateOrCreate(
+                    ['id' => $id],
+                    array_merge(['allergy_react_id' => $reactionId], $rm)
+                );
+            }
+
+            foreach ($r['note'] as $rn) {
+                $id = isset($rn['id']) ? $rn['id'] : null;
+                unset($rn['id']);
+                unset($rn['allergy_react_id']);
+
+                $reaction->note()->updateOrCreate(
+                    ['id' => $id],
+                    array_merge(['allergy_react_id' => $reactionId], $rn)
+                );
+            }
+        }
+
+        $resource->refresh();
+
+        $resourceText = new AllergyIntoleranceResource($resource);
+        $resource->content()->create([
+            'res_ver' => $resourceVersion,
+            'res_text' => json_encode($resourceText),
+        ]);
+
+        return response()->json($resource->allergyIntolerance->first(), 201);
+        // });
     }
 }

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -49,6 +49,7 @@ class NewPasswordController extends Controller
                 $user->forceFill([
                     'password' => Hash::make($request->password),
                     'remember_token' => Str::random(60),
+                    'password_changed_at' => now()
                 ])->save();
 
                 event(new PasswordReset($user));

--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -22,6 +22,7 @@ class PasswordController extends Controller
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),
+            'password_changed_at' => now()
         ]);
 
         return back();

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,9 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Resources\FhirResource;
 use App\Models\Resource;
-use App\Models\ResourceContent;
 use Exception;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -16,6 +14,20 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;
 
+
+    public function updateChildModels(object $parent, array $data, array $children, string $foreignKey, int $fkValue)
+    {
+        foreach ($children as $c) {
+            $this->updateInstances($parent, $c, $data, $foreignKey, $fkValue);
+        }
+    }
+
+    public function createChildModels(object $parent, array $data, array $children)
+    {
+        foreach ($children as $c) {
+            $this->createInstances($parent, $c, $data);
+        }
+    }
 
     public function updateNestedInstances(object $parent, string $child, array $data, string $foreignKey, int $fkValue, array $descendants, string $descendantKey)
     {

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -20,7 +20,7 @@ class ResourceController extends Controller
         return response()->json(Resource::where('res_type', '=', $res_type)->get(), 200);
     }
 
-    public function show($res_type, $satusehat_id)
+    public function show($res_type, $res_id)
     {
         if (!in_array($res_type, Resource::VALID_RESOURCE_TYPES)) {
             return response()->json(['error' => 'Invalid resource type.'], 400);
@@ -28,7 +28,7 @@ class ResourceController extends Controller
 
         try {
             return response()->json(Resource::where([
-                ['satusehat_id', '=', $satusehat_id],
+                ['id', '=', $res_id],
                 ['res_type', '=', $res_type]
             ])->firstOrFail()->$res_type->first(), 200);
         } catch (ModelNotFoundException $e) {

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Log;
 
 class ResourceController extends Controller
 {
-    public function indexResource($res_type)
+    public function index($res_type)
     {
         // Validate the resource type
         if (!in_array($res_type, Resource::VALID_RESOURCE_TYPES)) {
@@ -20,7 +20,7 @@ class ResourceController extends Controller
         return response()->json(Resource::where('res_type', '=', $res_type)->get(), 200);
     }
 
-    public function getResource($res_type, $satusehat_id)
+    public function show($res_type, $satusehat_id)
     {
         if (!in_array($res_type, Resource::VALID_RESOURCE_TYPES)) {
             return response()->json(['error' => 'Invalid resource type.'], 400);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'password_changed_at'
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,6 +81,7 @@ Route::post('/composition/create', [CompositionController::class, 'store']);
 
 // ClinicalImpression resource endpoint
 Route::post('/clinicalimpression/create', [ClinicalImpressionController::class, 'store']);
+Route::put('/clinicalimpression/{res_id}', [ClinicalImpressionController::class, 'update']);
 
 // ServiceRequest resource endpoint
 Route::post('/servicerequest/create', [ServiceRequestController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,7 +46,7 @@ Route::group(['middleware' => ['web']], function () {
 
 // Local DB resource endpoint
 Route::get('/{res_type}', [ResourceController::class, 'index']);
-Route::get('/{res_type}/{satusehat_id}', [ResourceController::class, 'show']);
+Route::get('/{res_type}/{res_id}', [ResourceController::class, 'show']);
 
 // Patient resource endpoint
 Route::post('/patient/create', [PatientController::class, 'store']);
@@ -59,7 +59,7 @@ Route::post('/condition/create', [ConditionController::class, 'store']);
 
 // AllergyIntolerance resource endpoint
 Route::post('/allergyintolerance/create', [AllergyIntoleranceController::class, 'store']);
-Route::post('/allergyintolerance/update', [AllergyIntoleranceController::class, 'update']);
+Route::put('/allergyintolerance/{res_id}', [AllergyIntoleranceController::class, 'update']);
 
 // Observation resource endpoint
 Route::post('/observation/create', [ObservationController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,44 +45,45 @@ Route::group(['middleware' => ['web']], function () {
 
 
 // Local DB resource endpoint
-Route::get('/{res_type}', [ResourceController::class, 'indexResource']);
-Route::get('/{res_type}/{satusehat_id}', [ResourceController::class, 'getResource']);
+Route::get('/{res_type}', [ResourceController::class, 'index']);
+Route::get('/{res_type}/{satusehat_id}', [ResourceController::class, 'show']);
 
 // Patient resource endpoint
-Route::post('/patient/create', [PatientController::class, 'postPatient']);
+Route::post('/patient/create', [PatientController::class, 'store']);
 
 // Encounter resource endpoint
-Route::post('/encounter/create', [EncounterController::class, 'postEncounter']);
+Route::post('/encounter/create', [EncounterController::class, 'store']);
 
 // Condition resource endpoint
-Route::post('/condition/create', [ConditionController::class, 'postCondition']);
+Route::post('/condition/create', [ConditionController::class, 'store']);
 
 // AllergyIntolerance resource endpoint
-Route::post('/allergyintolerance/create', [AllergyIntoleranceController::class, 'postAllergyIntolerance']);
+Route::post('/allergyintolerance/create', [AllergyIntoleranceController::class, 'store']);
+Route::post('/allergyintolerance/update', [AllergyIntoleranceController::class, 'update']);
 
 // Observation resource endpoint
-Route::post('/observation/create', [ObservationController::class, 'postObservation']);
+Route::post('/observation/create', [ObservationController::class, 'store']);
 
 // Procedure resource endpoint
-Route::post('/procedure/create', [ProcedureController::class, 'postProcedure']);
+Route::post('/procedure/create', [ProcedureController::class, 'store']);
 
 // Medication resource endpoint
-Route::post('/medication/create', [MedicationController::class, 'postMedication']);
+Route::post('/medication/create', [MedicationController::class, 'store']);
 
 // MedicationRequest resource endpoint
-Route::post('/medicationrequest/create', [MedicationRequestController::class, 'postMedicationRequest']);
+Route::post('/medicationrequest/create', [MedicationRequestController::class, 'store']);
 
 // MedicationDispense resource endpoint
-Route::post('/medicationdispense/create', [MedicationDispenseController::class, 'postMedicationDispense']);
+Route::post('/medicationdispense/create', [MedicationDispenseController::class, 'store']);
 
 // Composition resource endpoint
-Route::post('/composition/create', [CompositionController::class, 'postComposition']);
+Route::post('/composition/create', [CompositionController::class, 'store']);
 
 // ClinicalImpression resource endpoint
-Route::post('/clinicalimpression/create', [ClinicalImpressionController::class, 'postClinicalImpression']);
+Route::post('/clinicalimpression/create', [ClinicalImpressionController::class, 'store']);
 
 // ServiceRequest resource endpoint
-Route::post('/servicerequest/create', [ServiceRequestController::class, 'postServiceRequest']);
+Route::post('/servicerequest/create', [ServiceRequestController::class, 'store']);
 
 // Testing endpoint
 Route::get('/test-get/servicerequest/{satusehat_id}', [TestController::class, 'testServiceRequestResource']);

--- a/storage/example-payload/allergyintolerance-update.json
+++ b/storage/example-payload/allergyintolerance-update.json
@@ -1,8 +1,10 @@
 {
     "allergy_intolerance": {
+        "id": 1,
+        "resource_id": 1,
         "clinical_status": "active",
         "verification_status": "unconfirmed",
-        "type": "allergy",
+        "type": "intolerance",
         "category_food": true,
         "category_medication": false,
         "category_environment": false,
@@ -42,20 +44,29 @@
             },
             "onsetString": "sehari-hari"
         },
-        "recorded_date": "2023-11-01T11:16:01+07:00",
+        "recorded_date": "2023-11-01T11.16.01+07:00",
         "recorder": "Practitioner/1000400104",
         "asserter": "Practitioner-1000400104",
         "last_occurence": "2023-11-02T10:31:00+07:00"
     },
     "identifier": [
         {
+            "id": 1,
+            "allergy_id": 1,
             "system": "http://sys-ids.kemkes.go.id/allergy/10000004",
             "use": "official",
             "value": "5234342"
+        },
+        {
+            "system": "http://sys-ids.kemkes.go.id/allergy/10000004",
+            "use": "official",
+            "value": "5234347"
         }
     ],
     "note": [
         {
+            "id": 1,
+            "allergy_id": 1,
             "author": {
                 "authorString": "Dokter Bronsig",
                 "authorReference": {
@@ -69,6 +80,8 @@
     "reaction": [
         {
             "reaction_data": {
+                "id": 1,
+                "allergy_id": 1,
                 "substance_system": "http://terminology.kemkes.go.id/CodeSystem/clinical-term",
                 "substance_code": "AL000024",
                 "substance_display": "Kuning telur",
@@ -81,6 +94,8 @@
             },
             "manifestation": [
                 {
+                    "id": 1,
+                    "allergy_react_id": 1,
                     "system": "http://snomed.info/sct",
                     "code": "195967001",
                     "display": "Asthma"
@@ -88,6 +103,8 @@
             ],
             "note": [
                 {
+                    "id": 1,
+                    "allergy_react_id": 1,
                     "author": {
                         "authorString": "Dokter Bronsig",
                         "authorReference": {

--- a/storage/example-payload/clinicalimpression.json
+++ b/storage/example-payload/clinicalimpression.json
@@ -78,7 +78,7 @@
             "reference": "RiskAssessment/null"
         }
     ],
-    "supporting_info": [
+    "supportingInfo": [
         {
             "reference": "Resource/null"
         }

--- a/tests/Feature/AllergyIntoleranceDataTest.php
+++ b/tests/Feature/AllergyIntoleranceDataTest.php
@@ -6,7 +6,6 @@ use App\Models\AllergyIntolerance;
 use App\Models\Resource;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Tests\Traits\FhirTest;
 
@@ -25,19 +24,13 @@ class AllergyIntoleranceDataTest extends TestCase
 
         $data = $this->getExampleData('allergyintolerance');
 
-        $resource = Resource::create(
-            [
-                'satusehat_id' => '000001',
-                'res_type' => 'AllergyIntolerance',
-                'res_ver' => 1
-            ]
-        );
+        $headers = [
+            'Content-Type' => 'application/json'
+        ];
+        $response = $this->json('POST', '/api/allergyintolerance/create', $data, $headers);
+        $newData = json_decode($response->getContent(), true);
 
-        $allergyData = array_merge(['resource_id' => $resource->id], $data['allergy_intolerance']);
-
-        AllergyIntolerance::create($allergyData);
-
-        $response = $this->json('GET', 'api/allergyintolerance/' . $resource->id);
+        $response = $this->json('GET', 'api/allergyintolerance/' . $newData['resource_id']);
         $response->assertStatus(200);
     }
 
@@ -51,6 +44,7 @@ class AllergyIntoleranceDataTest extends TestCase
         $this->actingAs($user);
 
         $data = $this->getExampleData('allergyintolerance');
+
         $headers = [
             'Content-Type' => 'application/json'
         ];

--- a/tests/Feature/AllergyIntoleranceDataTest.php
+++ b/tests/Feature/AllergyIntoleranceDataTest.php
@@ -6,6 +6,7 @@ use App\Models\AllergyIntolerance;
 use App\Models\Resource;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use Tests\Traits\FhirTest;
 
@@ -54,6 +55,53 @@ class AllergyIntoleranceDataTest extends TestCase
             'Content-Type' => 'application/json'
         ];
         $response = $this->json('POST', '/api/allergyintolerance/create', $data, $headers);
+        $response->assertStatus(201);
+
+        $this->assertMainData('allergy_intolerance', $data['allergy_intolerance']);
+        $this->assertManyData('allergy_intolerance_identifier', $data['identifier']);
+        $this->assertManyData('allergy_intolerance_note', $data['note']);
+        $this->assertNestedData('allergy_intolerance_reaction', $data['reaction'], 'reaction_data', [
+            [
+                'table' => 'allergy_react_manifest',
+                'data' => 'manifestation'
+            ],
+            [
+                'table' => 'allergy_react_note',
+                'data' => 'note'
+            ]
+        ]);
+    }
+
+
+    /**
+     * Test apakah user dapat memperbarui data alergi pasien
+     */
+    public function test_users_can_update_allergy_intolerance_data()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $data = $this->getExampleData('allergyintolerance');
+        $headers = [
+            'Content-Type' => 'application/json'
+        ];
+        $response = $this->json('POST', '/api/allergyintolerance/create', $data, $headers);
+        $newData = json_decode($response->getContent(), true);
+
+        $data['allergy_intolerance']['id'] = $newData['id'];
+        $data['allergy_intolerance']['resource_id'] = $newData['resource_id'];
+        $data['allergy_intolerance']['type'] = 'intolerance';
+        $data['identifier'][0]['id'] = $newData['identifier'][0]['id'];
+        $data['identifier'][0]['allergy_id'] = $newData['identifier'][0]['allergy_id'];
+        $data['identifier'][0]['value'] = "5234341";
+
+        $data['identifier'][] = [
+            'system' => 'http://loinc.org',
+            'use' => 'official',
+            'value' => '1234567890'
+        ];
+
+        $response = $this->json('POST', '/api/allergyintolerance/update', $data, $headers);
         $response->assertStatus(201);
 
         $this->assertMainData('allergy_intolerance', $data['allergy_intolerance']);

--- a/tests/Feature/AllergyIntoleranceDataTest.php
+++ b/tests/Feature/AllergyIntoleranceDataTest.php
@@ -37,7 +37,7 @@ class AllergyIntoleranceDataTest extends TestCase
 
         AllergyIntolerance::create($allergyData);
 
-        $response = $this->json('GET', 'api/allergyintolerance/000001');
+        $response = $this->json('GET', 'api/allergyintolerance/' . $resource->id);
         $response->assertStatus(200);
     }
 
@@ -70,6 +70,10 @@ class AllergyIntoleranceDataTest extends TestCase
                 'data' => 'note'
             ]
         ]);
+        $this->assertDatabaseHas('resource_content', [
+            'res_ver' => 1,
+            'res_text' => '{"resourceType":"AllergyIntolerance","identifier":[{"system":"http:\/\/sys-ids.kemkes.go.id\/allergy\/10000004","use":"official","value":"5234342"}],"clinicalStatus":{"coding":[{"system":"http:\/\/terminology.hl7.org\/CodeSystem\/allergyintolerance-clinical","code":"active","display":"Active"}]},"verificationStatus":{"coding":[{"system":"http:\/\/terminology.hl7.org\/CodeSystem\/allergyintolerance-verification","code":"unconfirmed","display":"Unconfirmed"}]},"type":"allergy","category":["food"],"criticality":"low","code":{"coding":[{"system":"http:\/\/snomed.info\/sct","code":"89811004","display":"Gluten (substance)"}]},"patient":{"reference":"Patient\/100000030009"},"encounter":{"reference":"Encounter\/3dedcec9-885d-435e-9ac5-58853cb216bb"},"recordedDate":"2023-11-01T11:16:01+07:00","recorder":{"reference":"Practitioner\/1000400104"},"asserter":{"reference":"Practitioner-1000400104"},"lastOcurrence":"2023-11-02T10:31:00+07:00","note":[{"authorString":"Dokter Bronsig","authorReference":{"reference":"Practitioner\/1000400104"},"time":"2023-11-01T11:31:00+07:00","text":"# Catatan<br>## Subbab"}],"reaction":[{"substance":{"coding":[{"system":"http:\/\/terminology.kemkes.go.id\/CodeSystem\/clinical-term","code":"AL000024","display":"Kuning telur"}]},"manifestation":[{"coding":[{"system":"http:\/\/snomed.info\/sct","code":"195967001","display":"Asthma"}]}],"description":"Orang ini alergi kuning telur.","onset":"2023-11-02T10:45:00+07:00","severity":"mild","exposureRoute":{"coding":[{"system":"http:\/\/snomed.info\/sct","code":"6064005","display":"Topical route"}]},"note":[{"authorString":"Dokter Bronsig","authorReference":{"reference":"Practitioner\/1000400104"},"time":"2023-11-01T11:31:00+07:00","text":"# Catatan<br>## Subbab"}]}],"onsetDateTime":"2023-10-31T11:43:23+07:00","onsetAge":{"value":22,"comparator":"<","unit":"years","system":"http:\/\/unitsofmeasure.org","code":"a"},"onsetPeriod":{"start":"2023-11-15T14:56:34+07:00","end":"2023-11-15T15:56:34+07:00"},"onsetRange":{"low":{"value":10,"unit":"years","system":"http:\/\/unitsofmeasure.org","code":"a"},"high":{"value":25,"unit":"years","system":"http:\/\/unitsofmeasure.org","code":"a"}},"onsetString":"sehari-hari"}'
+        ]);
     }
 
 
@@ -101,8 +105,8 @@ class AllergyIntoleranceDataTest extends TestCase
             'value' => '1234567890'
         ];
 
-        $response = $this->json('POST', '/api/allergyintolerance/update', $data, $headers);
-        $response->assertStatus(201);
+        $response = $this->json('PUT', '/api/allergyintolerance/' . $newData['resource_id'], $data, $headers);
+        $response->assertStatus(200);
 
         $this->assertMainData('allergy_intolerance', $data['allergy_intolerance']);
         $this->assertManyData('allergy_intolerance_identifier', $data['identifier']);

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -64,6 +64,7 @@ class PasswordResetTest extends TestCase
             ]);
 
             $response->assertSessionHasNoErrors();
+            $this->assertNotNull($user->refresh()->password_changed_at);
 
             return true;
         });

--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -48,4 +48,19 @@ class PasswordUpdateTest extends TestCase
             ->assertSessionHasErrors('current_password')
             ->assertRedirect('/profile');
     }
+
+    public function test_timestamp_is_updated_on_password_update(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->from('/profile')->put('/password', [
+            'current_password' => 'password',
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ]);
+
+        $user->refresh();
+
+        $this->assertNotNull($user->password_changed_at);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to update existing Allergy Intolerance and Clinical Impression records.
  - Implemented tracking of password change timestamps for enhanced security.

- **Improvements**
  - Streamlined the creation and updating of resources using Eloquent relationships.
  - Refined API endpoints to follow RESTful conventions, improving consistency and predictability.
  - Enhanced test coverage for Allergy Intolerance and Clinical Impression data management.

- **Bug Fixes**
  - Ensured that the `password_changed_at` field is updated upon password reset and change.

- **Refactor**
  - Renamed methods in controllers to better reflect their actions (e.g., `postAllergyIntolerance` to `store`).
  - Reworked routing definitions to align with method name changes and added new routes for updates.

- **Tests**
  - Added new tests to verify the functionality of updating Allergy Intolerance and Clinical Impression data.
  - Updated existing tests to reflect changes in the API and to include new assertions for data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->