### PR TITLE
Add Consent API route

### DIFF
--- a/app/Console/Commands/RetryFailedApiRequests.php
+++ b/app/Console/Commands/RetryFailedApiRequests.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FailedApiRequest;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class RetryFailedApiRequests extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:retry-failed-api-requests';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $failedRequests = FailedApiRequest::all();
+
+        foreach ($failedRequests as $fr) {
+            try {
+                $method = $fr->method;
+
+                switch ($method) {
+                    case 'POST':
+                        $request = Request::create(route('integration.store', ['res_type' => $fr->res_type]), $method, json_decode($fr->data, true));
+                        break;
+                    case 'PUT':
+                        $request = Request::create(route('integration.update', ['res_type' => $fr->res_type, 'satusehat_id' => $fr->satusehat_id]), $method, json_decode($fr->data, true));
+                        break;
+                    default:
+                        throw new \Exception('Invalid method');
+                }
+
+                $response = app()->handle($request);
+
+                if ($response->isSuccessful()) {
+                    $fr->delete();
+                }
+            } catch (\Exception $e) {
+                // Log the error
+                Log::error('Failed to retry API request: ' . $e->getMessage());
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
+        $schedule->command('app:retry-failed-api-requests')->hourly();
     }
 
     /**
@@ -20,7 +21,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands(): void
     {
-        $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__ . '/Commands');
 
         require base_path('routes/console.php');
     }

--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -83,7 +83,7 @@ class IntegrationController extends Controller
             Log::error('Resource type mismatch', $res_type, $data['resourceType']);
             return response()->json(['error' => 'Resource type mismatch'], 400);
         } else {
-            $satusehatRequest = Request::create(route('satusehat.store', ['res_type' => $res_type]), 'POST', $data);
+            $satusehatRequest = Request::create(route('satusehat.resource.store', ['res_type' => $res_type]), 'POST', $data);
 
             $satusehatResponse = retry(3, function () use ($satusehatRequest) {
                 return app()->handle($satusehatRequest);
@@ -124,7 +124,7 @@ class IntegrationController extends Controller
             Log::error('Resource type mismatch', $res_type, $data['resourceType']);
             return response()->json(['error' => 'Resource type mismatch'], 400);
         } else {
-            $satusehatRequest = Request::create(route('satusehat.update', ['res_type' => $res_type, 'res_id' => $satusehat_id]), 'PUT', $data);
+            $satusehatRequest = Request::create(route('satusehat.resource.update', ['res_type' => $res_type, 'res_id' => $satusehat_id]), 'PUT', $data);
 
             $satusehatResponse = retry(3, function () use ($satusehatRequest) {
                 return app()->handle($satusehatRequest);

--- a/app/Http/Controllers/SatusehatController.php
+++ b/app/Http/Controllers/SatusehatController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Fhir\Satusehat;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Fhir\ConsentRequest;
 use App\Http\Requests\FhirRequest;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
@@ -33,6 +34,45 @@ class SatusehatController extends Controller
         $this->clientId = config('app.client_id');
         $this->clientSecret = config('app.client_secret');
         $this->organizationId = config('app.organization_id');
+    }
+
+    public function readConsent($patientId)
+    {
+        $token = $this->getToken();
+
+        $client = new Client();
+
+        $url = $this->consentUrl . '/Consent';
+
+        $response = $client->request('GET', $url, [
+            'headers' => ['Authorization' => 'Bearer ' . $token],
+            'query' => ['patient_id' => $patientId],
+            'verify' => false,
+        ]);
+
+        return $response;
+    }
+
+    public function updateConsent(ConsentRequest $request)
+    {
+        $token = $this->getToken();
+
+        $client = new Client();
+
+        $url = $this->consentUrl . '/Consent';
+
+        $data = $request->validated();
+
+        $response = $client->request('POST', $url, [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type' => 'application/json',
+            ],
+            'json' => $data,
+            'verify' => false,
+        ]);
+
+        return $response;
     }
 
     public function searchKfaProduct(

--- a/app/Http/Requests/Fhir/ConsentRequest.php
+++ b/app/Http/Requests/Fhir/ConsentRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Fhir;
+
+use App\Http\Requests\FhirRequest;
+
+class ConsentRequest extends FhirRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'patient_id' => 'required|string|exists:identifiers,value',
+            'action' => 'required|in:OPTIN,OPTOUT',
+            'agent' => 'required|string'
+        ];
+    }
+}

--- a/app/Http/Requests/Fhir/PatientRequest.php
+++ b/app/Http/Requests/Fhir/PatientRequest.php
@@ -21,7 +21,7 @@ class PatientRequest extends FhirRequest
             [
                 'identifier' => 'required|array',
                 'active' => 'nullable|boolean',
-                'name' => 'required|array',
+                'name' => 'nullable|array',
                 'telecom' => 'nullable|array',
                 'gender' => ['nullable', Rule::in(Patient::GENDER['binding']['valueset'])],
                 'birthDate' => 'nullable|date',

--- a/database/migrations/2024_01_03_204112_create_failed_api_requests_table.php
+++ b/database/migrations/2024_01_03_204112_create_failed_api_requests_table.php
@@ -14,6 +14,8 @@ return new class extends Migration
         Schema::create('failed_api_requests', function (Blueprint $table) {
             $table->id();
             $table->string('method');
+            $table->string('res_type');
+            $table->string('satusehat_id')->nullable();
             $table->json('data');
             $table->timestamps();
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,10 +52,16 @@ Route::post('/integration/{res_type}', [IntegrationController::class, 'store'])-
 Route::put('/integration/{res_type}/{satusehat_id}', [IntegrationController::class, 'update'])->name('integration.update');
 
 
-// SATUSEHAT resource endpoint
-Route::get('/satusehat/{res_type}/{res_id}', [SatusehatController::class, 'show'])->name('satusehat.show');
-Route::post('/satusehat/{res_type}', [SatusehatController::class, 'store'])->name('satusehat.store');
-Route::put('/satusehat/{res_type}/{res_id}', [SatusehatController::class, 'update'])->name('satusehat.update');
+Route::prefix('/satusehat/resource')->group(function () {
+    Route::get('/{res_type}/{res_id}', [SatusehatController::class, 'show'])->name('satusehat.resource.show');
+    Route::post('/{res_type}', [SatusehatController::class, 'store'])->name('satusehat.resource.store');
+    Route::put('/{res_type}/{res_id}', [SatusehatController::class, 'update'])->name('satusehat.resource.update');
+});
+
+// SATUSEHAT consent endpoint
+Route::get('/satusehat/consent/{patient_id}', [SatusehatController::class, 'readConsent'])->name('satusehat.consent.show');
+Route::post('/satusehat/consent', [SatusehatController::class, 'updateConsent'])->name('satusehat.consent.store');
+
 
 
 // Web APIs

--- a/tests/Unit/IntegrationTest.php
+++ b/tests/Unit/IntegrationTest.php
@@ -115,7 +115,7 @@ class IntegrationTest extends TestCase
         $this->json('POST', route('organization.store'), $data, $headers);
 
         $this->put(
-            route('satusehat.update', ['res_type' => 'organization', 'res_id' => '5fe612fe-eb92-4034-9337-7ad60ab15b94']),
+            route('satusehat.resource.update', ['res_type' => 'organization', 'res_id' => '5fe612fe-eb92-4034-9337-7ad60ab15b94']),
             $data
         );
 

--- a/tests/Unit/SatusehatTest.php
+++ b/tests/Unit/SatusehatTest.php
@@ -8,19 +8,19 @@ use Tests\TestCase;
 
 class SatusehatTest extends TestCase
 {
-    // public function test_get_auth_token(): void
-    // {
-    //     $controller = new SatusehatController();
-    //     $token = $controller->getToken();
-    //     $this->assertIsString($token);
-    // }
+    public function test_get_auth_token(): void
+    {
+        $controller = new SatusehatController();
+        $token = $controller->getToken();
+        $this->assertIsString($token);
+    }
 
     public function test_get_resource(): void
     {
         $resType = 'Practitioner';
         $resId = 'N10000001';
 
-        $response = $this->get(route('satusehat.show', ['res_type' => $resType, 'res_id' => $resId]));
+        $response = $this->get(route('satusehat.resource.show', ['res_type' => $resType, 'res_id' => $resId]));
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -50,9 +50,9 @@ class SatusehatTest extends TestCase
 
         $resType = $dataArray['resourceType'];
 
-        $response = $this->post(route('satusehat.store', ['res_type' => $resType]), $dataArray);
+        $response = $this->post(route('satusehat.resource.store', ['res_type' => $resType]), $dataArray);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
         $response->assertJsonFragment(['resourceType' => $resType]);
         $response->assertJsonFragment(['name' => $dataArray['name']]);
         $response->assertJsonStructure([
@@ -85,7 +85,7 @@ class SatusehatTest extends TestCase
 
         $resType = $dataArray['resourceType'];
 
-        $response = $this->put(route('satusehat.update', ['res_type' => $resType, 'res_id' => $satusehatId]), $dataArray);
+        $response = $this->put(route('satusehat.resource.update', ['res_type' => $resType, 'res_id' => $satusehatId]), $dataArray);
 
         $response->assertStatus(200);
         $response->assertJsonFragment(['resourceType' => $resType]);
@@ -95,6 +95,53 @@ class SatusehatTest extends TestCase
             'resourceType',
             'id',
             'meta'
+        ]);
+    }
+
+    public function test_read_consent()
+    {
+        $response = $this->get(route('satusehat.consent.show', ['patient_id' => 'P02478375538']));
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'resourceType',
+            'id',
+            'status',
+            'scope',
+            'category',
+            'patient',
+            'dateTime',
+            'organization',
+            'policyRule',
+            'provision'
+        ]);
+    }
+
+    public function test_update_consent()
+    {
+        $resp = $this->get(route('integration.show', ['res_type' => 'Patient', 'satusehat_id' => 'P02478375538']));
+
+        $this->assertDatabaseCount('patient', 1);
+
+        $consentData = [
+            'patient_id' => 'P02478375538',
+            'action' => 'OPTOUT',
+            'agent' => fake()->name()
+        ];
+
+        $response = $this->post(route('satusehat.consent.store'), $consentData);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'resourceType',
+            'id',
+            'status',
+            'scope',
+            'category',
+            'patient',
+            'dateTime',
+            'organization',
+            'policyRule',
+            'provision'
         ]);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new console command to retry failed API requests automatically on an hourly basis.
	- Added new routes and methods for managing consent information in the `IntegrationController` and `SatusehatController`.

- **Enhancements**
	- Updated route names for creating and updating requests to improve clarity and consistency.
	- Adjusted the database schema to include additional fields for better tracking of failed API requests.

- **Bug Fixes**
	- Made the 'name' field in `PatientRequest` nullable to align with updated validation rules.

- **Documentation**
	- Updated API route documentation to reflect the new structure and consent management endpoints.

- **Tests**
	- Modified unit tests to use the updated route names and test new consent management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->